### PR TITLE
Ignore class field used for implementing the Android Parcelable interface

### DIFF
--- a/UnpackProcessor/src/main/kotlin/oliviazoe0/processor/UnpackCodeGenerator.kt
+++ b/UnpackProcessor/src/main/kotlin/oliviazoe0/processor/UnpackCodeGenerator.kt
@@ -42,7 +42,7 @@ class UnpackCodeGenerator : AbstractProcessor() {
     private fun generateClass(className: String, pkg: String, element: Element){
         val parcelableCreatorName = "CREATOR" // Ignore class field used for implementing the Android Parcelable interface
         val classVariables = element.enclosedElements
-            .filter { it.kind == ElementKind.FIELD && it.simpleName != parcelableCreatorName } // Grab the variables
+            .filter { it.kind == ElementKind.FIELD && it.simpleName.toString() != parcelableCreatorName } // Grab the variables
         if (classVariables.isEmpty()) return; // Self-explanatory
 
         val file = FileSpec.builder(pkg, className)

--- a/UnpackProcessor/src/main/kotlin/oliviazoe0/processor/UnpackCodeGenerator.kt
+++ b/UnpackProcessor/src/main/kotlin/oliviazoe0/processor/UnpackCodeGenerator.kt
@@ -20,7 +20,6 @@ class UnpackCodeGenerator : AbstractProcessor() {
         // Find elements with the annotation
         val annotatedElements = roundEnv.getElementsAnnotatedWith(AutoUnpack::class.java)
         if(annotatedElements.isEmpty()) {
-            // Self-explanatory
             return false;
         }
         // Iterate the elements
@@ -40,10 +39,13 @@ class UnpackCodeGenerator : AbstractProcessor() {
     }
 
     private fun generateClass(className: String, pkg: String, element: Element){
-        val parcelableCreatorName = "CREATOR" // Ignore class field used for implementing the Android Parcelable interface
+        
         val classVariables = element.enclosedElements
-            .filter { it.kind == ElementKind.FIELD && it.simpleName.toString() != parcelableCreatorName } // Grab the variables
-        if (classVariables.isEmpty()) return; // Self-explanatory
+            .filter {
+                it.kind == ElementKind.FIELD // Find fields
+                        && Modifier.STATIC !in it.modifiers // that aren't static
+            } // Grab the variables
+        if (classVariables.isEmpty()) return; 
 
         val file = FileSpec.builder(pkg, className)
             .addFunction(FunSpec.builder("iterator") // For automatic unpacking in a for loop

--- a/UnpackProcessor/src/main/kotlin/oliviazoe0/processor/UnpackCodeGenerator.kt
+++ b/UnpackProcessor/src/main/kotlin/oliviazoe0/processor/UnpackCodeGenerator.kt
@@ -40,8 +40,9 @@ class UnpackCodeGenerator : AbstractProcessor() {
     }
 
     private fun generateClass(className: String, pkg: String, element: Element){
+        val parcelableCreatorName = "CREATOR" // Ignore class field used for implementing the Android Parcelable interface
         val classVariables = element.enclosedElements
-            .filter { it.kind == ElementKind.FIELD } // Grab the variables
+            .filter { it.kind == ElementKind.FIELD && it.simpleName != parcelableCreatorName } // Grab the variables
         if (classVariables.isEmpty()) return; // Self-explanatory
 
         val file = FileSpec.builder(pkg, className)


### PR DESCRIPTION
I've made this change to solve this issue https://github.com/LunarWatcher/KClassUnpacker/issues/1

Can you please review it?